### PR TITLE
Remove current_record from earnings_rates scope

### DIFF
--- a/lib/xeroizer/models/payroll/pay_items.rb
+++ b/lib/xeroizer/models/payroll/pay_items.rb
@@ -22,6 +22,7 @@ module Xeroizer
 
         has_many      :earnings_types # US
 
+        scope_attribute :earnings_rates, proc { select { |er| er['current_record'] } }
       end
 
     end

--- a/lib/xeroizer/record/record_association_helper.rb
+++ b/lib/xeroizer/record/record_association_helper.rb
@@ -191,6 +191,11 @@ module Xeroizer
           end
         end
 
+        def scope_attribute(attr_name, block)
+          attributes = self.attributes[attr_name]
+          self.attributes[attr_name] = attributes.instance_eval(&block)
+        end
+
 
         def value_if_nil(association_type, boxed_value = nil)
           case association_type


### PR DESCRIPTION
Inactive earnings rates cause conflicts when exporting to payroll. I don't think we ever look at any inactive items for this, so wanted to resolve it at the root.