### PR TITLE
PFC-4916 (fix) Add new fields for STP Phase two

### DIFF
--- a/lib/xeroizer/models/payroll/leave_type.rb
+++ b/lib/xeroizer/models/payroll/leave_type.rb
@@ -21,7 +21,7 @@ module Xeroizer
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 
-        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip, :leave_category_code, :SGC_exempt
+        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip, :SGC_exempt
 
       end
 

--- a/lib/xeroizer/models/payroll/leave_type.rb
+++ b/lib/xeroizer/models/payroll/leave_type.rb
@@ -17,7 +17,7 @@ module Xeroizer
         decimal       :normal_entitlement
         decimal       :leave_loading_rate
         string        :leave_category_code, api_name: 'LeaveCategoryCode' # https://developer.xero.com/documentation/api/payrollau/payitems#elements-for-leavetypes
-        string        :SGC_exempt, api_name: 'SGCExempt' # https://developer.xero.com/documentation/api/payrollau/payitems#elements-for-leavetypes
+        boolean       :SGC_exempt, api_name: 'SGCExempt' # list of what is exempt here: https://developer.xero.com/documentation/api/payrollau/types-and-codes#leavecategory
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 

--- a/lib/xeroizer/models/payroll/leave_type.rb
+++ b/lib/xeroizer/models/payroll/leave_type.rb
@@ -21,7 +21,7 @@ module Xeroizer
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 
-        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip, :SGC_exempt
+        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip
 
       end
 

--- a/lib/xeroizer/models/payroll/leave_type.rb
+++ b/lib/xeroizer/models/payroll/leave_type.rb
@@ -10,16 +10,17 @@ module Xeroizer
 
         string        :name
         string        :type_of_units
-        boolean       :is_paid_leave
+        boolean       :is_paid_leave # if paid leave this will need :leave_category_code
         boolean       :show_on_payslip
 
         guid          :leave_type_id
         decimal       :normal_entitlement
         decimal       :leave_loading_rate
+        string        :leave_category_code, api_name: 'LeaveCategoryCode' # https://developer.xero.com/documentation/api/payrollau/payitems#elements-for-leavetypes
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 
-        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip
+        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip, :leave_category_code
 
       end
 

--- a/lib/xeroizer/models/payroll/leave_type.rb
+++ b/lib/xeroizer/models/payroll/leave_type.rb
@@ -17,10 +17,11 @@ module Xeroizer
         decimal       :normal_entitlement
         decimal       :leave_loading_rate
         string        :leave_category_code, api_name: 'LeaveCategoryCode' # https://developer.xero.com/documentation/api/payrollau/payitems#elements-for-leavetypes
+        string        :SGC_exempt, api_name: 'SGCExempt' # https://developer.xero.com/documentation/api/payrollau/payitems#elements-for-leavetypes
 
         datetime_utc  :updated_date_utc, :api_name => 'UpdatedDateUTC'
 
-        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip, :leave_category_code
+        validates_presence_of :name, :type_of_units, :is_paid_leave, :show_on_payslip, :leave_category_code, :SGC_exempt
 
       end
 

--- a/test/stub_responses/payroll_pay_items.xml
+++ b/test/stub_responses/payroll_pay_items.xml
@@ -127,78 +127,111 @@
     </ReimbursementTypes>
     <LeaveTypes>
       <LeaveType>
-        <LeaveTypeID>bd2ead8d-f8f9-480a-8a71-260222ed1a34</LeaveTypeID>
+        <LeaveTypeID>e8161385-30d0-4ac2-a11a-e81e30302d41</LeaveTypeID>
         <Name>Annual Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <NormalEntitlement>152.0000</NormalEntitlement>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>true</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <LeaveCategoryCode>ANNUALLEAVE</LeaveCategoryCode>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>cd61fd41-671b-4d1f-ad6e-fbcb1eca3fc3</LeaveTypeID>
+        <LeaveTypeID>60b2a5aa-b146-49f9-bf90-70f6ad8c333e</LeaveTypeID>
         <Name>Long Service Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <LeaveCategoryCode>LONGSERVICELEAVE</LeaveCategoryCode>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>c06359d4-ee61-4f74-9c74-f94ef6a850e3</LeaveTypeID>
+        <LeaveTypeID>c59c4d33-d22d-4f8b-b613-3b6bf6882bd7</LeaveTypeID>
         <Name>Parental Leave (unpaid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>271814d6-1087-45f2-923a-8301113a298b</LeaveTypeID>
+        <LeaveTypeID>d2342b56-65f5-42ad-a8c6-635fbdfcac19</LeaveTypeID>
         <Name>Personal/Carer's Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <NormalEntitlement>76.0000</NormalEntitlement>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <LeaveCategoryCode>PERSONALSICKCARERSLEAVE</LeaveCategoryCode>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>f3a5f2f8-c14e-4223-ab58-4e779e0f6f2c</LeaveTypeID>
+        <LeaveTypeID>ee486aad-310f-44c7-a734-b886cec06d20</LeaveTypeID>
         <Name>Carer's Leave (unpaid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>30ca48d0-fe04-40c2-b590-f5191159259f</LeaveTypeID>
+        <LeaveTypeID>83f600c5-5ed9-46f4-84f1-c70769de6f93</LeaveTypeID>
         <Name>Compassionate Leave (paid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <LeaveCategoryCode>COMPASSIONATEANDBEREAVEMENTLEAVE</LeaveCategoryCode>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>1e1765bc-1dbc-4ac9-b6cd-9f9f3290d8a4</LeaveTypeID>
+        <LeaveTypeID>3ed0e06d-eb74-45a3-83d4-492d1a8608bb</LeaveTypeID>
         <Name>Compassionate Leave (unpaid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>42d46756-9f2b-4456-ad44-8c889ff4a5bd</LeaveTypeID>
+        <LeaveTypeID>a0697213-4e83-47a0-b180-f9718c09d2be</LeaveTypeID>
         <Name>Community Service Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>7ea96a9f-d7c2-4de1-a3ac-bf89980f1890</LeaveTypeID>
+        <LeaveTypeID>8af9bd03-a957-4c5f-8e8e-038a5c4263ea</LeaveTypeID>
         <Name>Other Unpaid Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
+        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <SGCExempt>false</SGCExempt>
+      </LeaveType>
+      <LeaveType>
+        <LeaveTypeID>624fc546-d4f5-4a5a-abb0-347ac94f2e89</LeaveTypeID>
+        <Name>TOIL</Name>
+        <TypeOfUnits>Hours</TypeOfUnits>
+        <IsPaidLeave>true</IsPaidLeave>
+        <ShowOnPayslip>true</ShowOnPayslip>
+        <UpdatedDateUTC>2022-11-21T23:59:39</UpdatedDateUTC>
+        <CurrentRecord>true</CurrentRecord>
+        <LeaveCategoryCode>TIMEOFFINLIEU</LeaveCategoryCode>
+        <SGCExempt>false</SGCExempt>
       </LeaveType>
     </LeaveTypes>
   </PayItems>

--- a/test/stub_responses/payroll_pay_items.xml
+++ b/test/stub_responses/payroll_pay_items.xml
@@ -127,98 +127,98 @@
     </ReimbursementTypes>
     <LeaveTypes>
       <LeaveType>
-        <LeaveTypeID>e8161385-30d0-4ac2-a11a-e81e30302d41</LeaveTypeID>
+        <LeaveTypeID>bd2ead8d-f8f9-480a-8a71-260222ed1a34</LeaveTypeID>
         <Name>Annual Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <NormalEntitlement>152.0000</NormalEntitlement>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>true</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <LeaveCategoryCode>ANNUALLEAVE</LeaveCategoryCode>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>60b2a5aa-b146-49f9-bf90-70f6ad8c333e</LeaveTypeID>
+        <LeaveTypeID>cd61fd41-671b-4d1f-ad6e-fbcb1eca3fc3</LeaveTypeID>
         <Name>Long Service Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <LeaveCategoryCode>LONGSERVICELEAVE</LeaveCategoryCode>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>c59c4d33-d22d-4f8b-b613-3b6bf6882bd7</LeaveTypeID>
+        <LeaveTypeID>c06359d4-ee61-4f74-9c74-f94ef6a850e3</LeaveTypeID>
         <Name>Parental Leave (unpaid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>d2342b56-65f5-42ad-a8c6-635fbdfcac19</LeaveTypeID>
+        <LeaveTypeID>271814d6-1087-45f2-923a-8301113a298b</LeaveTypeID>
         <Name>Personal/Carer's Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <NormalEntitlement>76.0000</NormalEntitlement>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <LeaveCategoryCode>PERSONALSICKCARERSLEAVE</LeaveCategoryCode>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>ee486aad-310f-44c7-a734-b886cec06d20</LeaveTypeID>
+        <LeaveTypeID>f3a5f2f8-c14e-4223-ab58-4e779e0f6f2c</LeaveTypeID>
         <Name>Carer's Leave (unpaid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>83f600c5-5ed9-46f4-84f1-c70769de6f93</LeaveTypeID>
+        <LeaveTypeID>30ca48d0-fe04-40c2-b590-f5191159259f</LeaveTypeID>
         <Name>Compassionate Leave (paid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>true</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <LeaveCategoryCode>COMPASSIONATEANDBEREAVEMENTLEAVE</LeaveCategoryCode>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>3ed0e06d-eb74-45a3-83d4-492d1a8608bb</LeaveTypeID>
+        <LeaveTypeID>1e1765bc-1dbc-4ac9-b6cd-9f9f3290d8a4</LeaveTypeID>
         <Name>Compassionate Leave (unpaid)</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>a0697213-4e83-47a0-b180-f9718c09d2be</LeaveTypeID>
+        <LeaveTypeID>42d46756-9f2b-4456-ad44-8c889ff4a5bd</LeaveTypeID>
         <Name>Community Service Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <SGCExempt>false</SGCExempt>
       </LeaveType>
       <LeaveType>
-        <LeaveTypeID>8af9bd03-a957-4c5f-8e8e-038a5c4263ea</LeaveTypeID>
+        <LeaveTypeID>7ea96a9f-d7c2-4de1-a3ac-bf89980f1890</LeaveTypeID>
         <Name>Other Unpaid Leave</Name>
         <TypeOfUnits>Hours</TypeOfUnits>
         <IsPaidLeave>false</IsPaidLeave>
         <ShowOnPayslip>false</ShowOnPayslip>
-        <UpdatedDateUTC>2022-10-19T01:37:10</UpdatedDateUTC>
+        <UpdatedDateUTC>2013-04-09T23:45:25</UpdatedDateUTC>
         <CurrentRecord>true</CurrentRecord>
         <SGCExempt>false</SGCExempt>
       </LeaveType>


### PR DESCRIPTION
## Description of changes

This PR solves PFC-4916.

Xero now require LeaveCategoryCode to be in our POST requests with each PaidLeaveType.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/19569654/203200072-c9c66770-8015-4de3-8c9c-43e68bc6f480.png">

Image link: https://developer.xero.com/documentation/api/payrollau/payitems

## Notes for code reviewers

Add the `:leave_category_code` field to `leave_type.rb`. Updated the stub_responses `payroll_pay_items.xml` to include these extra fields

UPDATE: Have done the same for `SCGExmept`.

## Notes for testing

Point payaus repo to this branch and test POST requests there.