### PR TITLE
[Ruby 3.2] Replace `Fixnum` instance with `Integer`

### DIFF
--- a/lib/xeroizer/record/record_association_helper.rb
+++ b/lib/xeroizer/record/record_association_helper.rb
@@ -168,7 +168,7 @@ module Xeroizer
               when NilClass
                 self.attributes[field_name] = []
 
-              when Float, Fixnum
+              when Float, Integer
                 if record_class.fields.count == 1 && record_class.fields.keys.first == :value
                   self.attributes[field_name] = self.class.value_if_nil(association_type, value)
                 else


### PR DESCRIPTION
`Fixnum` has been deprecated since Ruby 2.4 and has been removed in Ruby 3.2
![image](https://github.com/TandaHQ/xeroizer/assets/13454550/3d0ed7f5-2d79-4af6-8f0e-cb0664b111a6)
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

`Fixnum` is basically just an alias for `Integer` in Ruby >= 2.4 and < 3.2
<img width="474" alt="image" src="https://github.com/TandaHQ/xeroizer/assets/13454550/1b9cf964-d76c-4fd3-9fe0-696a15f9a201">
<img width="433" alt="image" src="https://github.com/TandaHQ/xeroizer/assets/13454550/e5875c1f-97e2-4295-bfbd-1f76b6a39df1">